### PR TITLE
Added records-per-iteration for --server mode

### DIFF
--- a/datacraft/__init__.py
+++ b/datacraft/__init__.py
@@ -15,6 +15,6 @@ from .exceptions import SpecException, ResourceError
 from .supplier.exceptions import SupplierException
 # commonly used by client code
 from .loader import Loader
-from . import suppliers
+from . import suppliers, distributions, outputs
 # to trigger registered functions
 from . import cli

--- a/datacraft/__main__.py
+++ b/datacraft/__main__.py
@@ -4,12 +4,12 @@ Entry point for datacraft tool
 """
 import sys
 
-from . import cli
-from .exceptions import SpecException
+from . import cli, suppliers
 from .supplier.exceptions import SupplierException
 # this activates the decorators, so they will be discoverable
 from .preprocessor import *
 from .logging_handler import *
+
 
 _log = logging.getLogger(__name__)
 
@@ -33,7 +33,13 @@ def main(argv):
         try:
             from . import server
             using_template_or_formatter = args.template or args.format
-            server.run(generator, args.endpoint, data_is_json=(not using_template_or_formatter))
+            records_per_file = args.records_per_file
+            if records_per_file is None:
+                records_per_file = 1
+            server.run(generator,
+                       args.endpoint,
+                       data_is_json=(not using_template_or_formatter),
+                       count_supplier=suppliers.count_supplier(count=records_per_file))
         except ModuleNotFoundError:
             _log.warning('--server mode requires flask, pip/conda install flask and rerun command')
     else:

--- a/datacraft/_registered_types.py
+++ b/datacraft/_registered_types.py
@@ -17,8 +17,6 @@ from .supplier.common import weighted_values_explicit
 from .supplier.nested import nested_supplier
 # for refs
 from .supplier.refs import weighted_ref_supplier
-# for unicode ranges
-from .supplier.unicode import unicode_range_supplier
 # for calculate
 from .suppliers import calculate
 
@@ -731,6 +729,7 @@ def _select_list_subset_schema():
 def _configure_select_list_subset_supplier(field_spec, loader):
     """ configures supplier for select_list_subset type """
     config = utils.load_config(field_spec, loader)
+    data = None
     if config is None or ('mean' not in config and 'count' not in config):
         raise SpecException('Config with mean or count defined must be provided: %s' % json.dumps(field_spec))
     if 'ref' in field_spec and 'data' in field_spec:
@@ -748,6 +747,9 @@ def _configure_select_list_subset_supplier(field_spec, loader):
             data = field_spec
     elif 'data' in field_spec:
         data = field_spec.get('data')
+    if data is None:
+        raise SpecException(
+            'Unable to identify data for ' + _SELECT_LIST_SUBSET_KEY + ' for spec: ' + json.dumps(field_spec))
     return suppliers.select_list_subset(data, **config)
 
 

--- a/datacraft/builder.py
+++ b/datacraft/builder.py
@@ -8,7 +8,7 @@ Examples:
     >>> builder.range_spec('ages', data=[22, 33])
     {'names': {'type': 'values', 'data': ['amy', 'bob', 'cat', 'dan']}, 'ages': {'type': 'range', 'data': [22, 33]}}
 
-    >>> refs = spec_builder.refs()
+    >>> refs = builder.refs()
     >>> one = refs.values('ONE', ["A", "B", "C"])
     >>> two = refs.values('TWO', [1, 2, 3])
     >>> builder.combine('combine', refs=[one, two])
@@ -533,6 +533,7 @@ class Builder:
             self for chaining invocations
 
         Examples:
+            >>> import datacraft
             >>> builder = datacraft.spec_buider()
             >>> builder.add_fields(FIELDNAME1=builder.some_spec(with_args), FIELDNAME2=builder.another_spec(with_args)
         )
@@ -553,6 +554,7 @@ class Builder:
             self for chaining invocations
 
         Examples:
+            >>> import datacraft
             >>> builder = datacraft.spec_buider()
             >>> builder.add_field("field1", builder.some_spec(with_args))
             >>> builder.add_field("field2", builder.another_spec(with_args))
@@ -577,6 +579,7 @@ class Builder:
             self for chaining invocations
 
         Examples:
+            >>> import datacraft
             >>> builder = datacraft.spec_buider()
             >>> builder.add_refs(
             ...     REFNAME1=builder.some_spec(with_args),
@@ -598,6 +601,7 @@ class Builder:
             self for chaining invocations
 
         Examples:
+            >>> import datacraft
             >>> builder = datacraft.spec_builder()
             >>> builder.add_ref("ref1", builder.some_spec(with_args))
             >>> builder.add_ref("ref2", builder.another_spec(with_args))

--- a/datacraft/cli.py
+++ b/datacraft/cli.py
@@ -46,7 +46,7 @@ def parseargs(argv):
                         help='Extension to add to generated files, default is none')
     parser.add_argument('-t', '--template',
                         help='Path to template to populate, or template inline as a string')
-    parser.add_argument('-r', '--records-per-file', dest='records_per_file', default=sys.maxsize, type=int,
+    parser.add_argument('-r', '--records-per-file', dest='records_per_file', default=None, type=int,
                         help='Number of records to place in each file, default is all, requires -o to be specified')
     parser.add_argument('-k', '--printkey', action='store_true', default=False,
                         help='When printing to stdout field name should be printed along with value')
@@ -217,7 +217,10 @@ def _get_writer(args):
 def _get_output(args, processor, writer):
     """ get the output from the args, processor, and writer """
     if processor:
-        return outputs.record_level(processor, writer, args.records_per_file)
+        records_per_file = args.records_per_file
+        if records_per_file is None:
+            records_per_file = sys.maxsize
+        return outputs.record_level(processor, writer, records_per_file)
 
     return outputs.single_field(writer, args.printkey)
 

--- a/datacraft/preprocessor.py
+++ b/datacraft/preprocessor.py
@@ -125,7 +125,7 @@ def _preprocess_nested(raw_spec: dict, is_refs: bool = False) -> dict:
     Returns:
         converted spec
     """
-    updated_specs = {} # type: ignore
+    updated_specs = {}  # type: ignore
     if 'refs' in raw_spec:
         if 'refs' in updated_specs:
             updated_specs['refs'].update(_preprocess_spec(raw_spec['refs'], True))

--- a/datacraft/server.py
+++ b/datacraft/server.py
@@ -5,6 +5,7 @@ from typing import Generator
 import logging
 import flask
 
+import datacraft
 
 _log = logging.getLogger(__name__)
 
@@ -13,10 +14,16 @@ class _Server:
     """
     Light weight Flask server
     """
-    def __init__(self, generator, endpoint, data_is_json):
+    def __init__(self,
+                 generator: Generator,
+                 endpoint: str,
+                 data_is_json: bool,
+                 count_supplier: datacraft.ValueSupplierInterface):
         self.generator = generator
         self.endpoint = endpoint
         self.data_is_json = data_is_json
+        self.count_supplier = count_supplier
+        self.call_number = 0
 
     def callback(self):
         """
@@ -26,14 +33,19 @@ class _Server:
             data as JSON or raw, until stop iteration, then 204 no more content
         """
         # next generated record
+        num_records = self.count_supplier.next(self.call_number)
         try:
-            data = next(self.generator)
+            data = [next(self.generator) for _ in range(num_records)]
         except StopIteration:
             _log.warning('No more iterations available')
             return flask.Response(None, status=204)
         if self.data_is_json:
             return flask.jsonify(data)
-        return data
+        # this may already be json or templated data
+        if num_records == 1:
+            return data[0]
+        # cannot return list without jsonifying it
+        return flask.jsonify(data)
 
     def run(self):
         """ run the Flask app """
@@ -43,7 +55,10 @@ class _Server:
         app.run()
 
 
-def run(generator: Generator, endpoint: str, data_is_json: bool):
+def run(generator: Generator,
+        endpoint: str,
+        data_is_json: bool,
+        count_supplier: datacraft.ValueSupplierInterface):
     """
     Runs a light weight Flask server with data returned by the provided generator served at each subsequent call to
     the provided endpoint. End point should start with /. When StopIteration encountered, returns a 204 status code.
@@ -52,6 +67,7 @@ def run(generator: Generator, endpoint: str, data_is_json: bool):
         generator: that provides response data as dictionary
         endpoint: to serve data on i.e. /data
         data_is_json: if the data should be returned as JSON, default is as string
+        count_supplier: supplies the number of values to generate for each call
     """
-    server = _Server(generator, endpoint, data_is_json)
+    server = _Server(generator, endpoint, data_is_json, count_supplier)
     server.run()

--- a/datacraft/supplier/calculate.py
+++ b/datacraft/supplier/calculate.py
@@ -38,7 +38,7 @@ def calculate_supplier(suppliers: Dict[str, ValueSupplierInterface], engine: Rec
         >>> formula = "{{ft}} * 30.48"
         >>> suppliers = { "ft": suppliers.values([4, 5, 6]) }
         >>> calculate = _CalculateSupplier(suppliers=suppliers, formula=formula)
-        >>> asssert calculate.next(0) == 121.92
+        >>> assert calculate.next(0) == 121.92
     """
     return _CalculateSupplier(suppliers, engine)
 

--- a/datacraft/supplier/combine.py
+++ b/datacraft/supplier/combine.py
@@ -6,7 +6,9 @@ from typing import List
 from .model import ValueSupplierInterface
 
 
-def combine_supplier(suppliers_list: List[ValueSupplierInterface], join_with: str, as_list: bool) -> ValueSupplierInterface:
+def combine_supplier(suppliers_list: List[ValueSupplierInterface],
+                     join_with: str,
+                     as_list: bool) -> ValueSupplierInterface:
     """
     Args:
         suppliers_list: list of suppliers to combine in order of combination

--- a/datacraft/supplier/model.py
+++ b/datacraft/supplier/model.py
@@ -2,7 +2,8 @@
 Module to hold models for core data structures and classes
 """
 from abc import ABC, abstractmethod
-from typing import Union, Tuple, List, Any, Generator, Iterator
+from collections.abc import Iterator
+from typing import Union, Tuple, List, Any, Generator
 
 
 class DataSpec(dict):

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -68,8 +68,7 @@ separated value line. Examples:
 
 .. code-block:: shell
 
-    {"id": "549e418c-ade0-4995-befb-0149b3566e5e", "ts": "14-11-2050"}
-    {"id": "def0be82-2469-433b-a207-1eff54f3ba2c", "ts": "14-11-2050"}
+    [{"id": "732376df-9adc-413e-8493-73555fae51f9", "ts": "21-04-2022"}, {"id": "d826774a-1eeb-4e35-8253-0b00a514c0d1", "ts": "02-04-2022"}]
 
 .. code-block:: shell
 
@@ -77,14 +76,16 @@ separated value line. Examples:
 
 .. code-block:: shell
 
-    {
-        "id": "6f05c635-bf2c-4096-95ef-c3fa15bedbb3",
-        "ts": "29-11-2050"
-    }
-    {
-        "id": "8420ff4a-92ca-4218-b399-edcb8954f822",
-        "ts": "28-11-2050"
-    }
+   [
+       {
+           "id": "4a75d0fc-46b7-4c9b-82f1-c87dcee13674",
+           "ts": "09-04-2022"
+       },
+       {
+           "id": "62db293b-d8f8-4c9a-8653-6dba8713bab9",
+           "ts": "13-04-2022"
+       }
+   ]
 
 .. code-block:: shell
 
@@ -94,6 +95,29 @@ separated value line. Examples:
 
     f8b87f46-ebda-4364-a042-21e6ac117762,09-12-2050
     3b0c236c-3882-4242-9f3b-053ab3da4be8,12-12-2050
+
+Records Per File
+----------------
+
+When writing results to a file, the default behavior is to write all records to a single file. You can modify this
+by specifying the ``-r`` or ``--records-per-file`` command line argument. The behavior is different when hosting the
+generated data with the ``--server`` option. In this case the default is to return a single record at a time. Use the
+same ``--records-per-file`` command line argument to return more that one record per request.
+
+Examples:
+
+.. code-block:: shell
+
+   datacraft --inline "{timestamp:date: {}}" -i 4 -r 2 --log-level off --format json -x
+   [{"timestamp": "25-04-2022"}, {"timestamp": "06-04-2022"}]
+   [{"timestamp": "09-04-2022"}, {"timestamp": "09-04-2022"}]
+
+
+.. code-block:: shell
+
+   datacraft --inline "{timestamp:date: {}}" -i 4  --log-level off --format json -x
+   [{"timestamp": "22-04-2022"}, {"timestamp": "03-04-2022"}, {"timestamp": "10-04-2022"}, {"timestamp": "06-04-2022"}]
+
 
 Apply Raw
 ---------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,11 +5,11 @@ sys.path.insert(0, os.path.abspath('../../datacraft/'))
 # -- Project information
 
 project = 'Datacraft'
-copyright = '2021, Brian Buxton'
+copyright = '2022, Brian Buxton'
 author = 'Brian Buxton'
 
 release = '0.2'
-version = '0.2.1'
+version = '0.2.2'
 
 # -- General configuration
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -76,11 +76,11 @@ number between 1 and 100 that is cast to an integer. If we run this spec and spe
 .. code-block:: shell
 
     $ datacraft -s demo.json --log-level off -i 5 --format json -x
-    {"id": "706bf38c-02a8-4087-bf41-62cdf4963f0b", "timestamp": "2021-11-30T05:21:14", "count": 59}
-    {"id": "d96bad3e-45c3-424e-9d4e-1233f9ed6ab5", "timestamp": "2021-11-09T20:21:03", "count": 61}
-    {"id": "ff3b8d87-ab3d-4ebe-af35-a081ee5098b5", "timestamp": "2021-11-05T08:24:05", "count": 36}
-    {"id": "b6fbd17f-286b-4d58-aede-01901ae7a1d7", "timestamp": "2021-11-10T09:37:47", "count": 16}
-    {"id": "f4923efa-28c5-424a-8560-49914dd2b2ac", "timestamp": "2021-11-19T17:28:13", "count": 29}
+    {"id": "706bf38c-02a8-4087-bf41-62cdf4963f0b", "timestamp": "2050-11-30T05:21:14", "count": 59}
+    {"id": "d96bad3e-45c3-424e-9d4e-1233f9ed6ab5", "timestamp": "2050-11-09T20:21:03", "count": 61}
+    {"id": "ff3b8d87-ab3d-4ebe-af35-a081ee5098b5", "timestamp": "2050-11-05T08:24:05", "count": 36}
+    {"id": "b6fbd17f-286b-4d58-aede-01901ae7a1d7", "timestamp": "2050-11-10T09:37:47", "count": 16}
+    {"id": "f4923efa-28c5-424a-8560-49914dd2b2ac", "timestamp": "2050-11-19T17:28:13", "count": 29}
 
 There are other output formats available and a mechanism to register custom formatters. If a csv file is more suited
 for your needs:
@@ -88,11 +88,11 @@ for your needs:
 .. code-block:: shell
 
     $ datacraft -s demo.json --log-level off -i 5 --format csv -x
-    1ad0b69b-0843-4c0d-90a3-d7b77574a3af,2021-11-21T21:24:44,2
-    b504d688-6f02-4d41-8b05-f55a681b940a,2021-11-14T15:29:59,76
-    11502944-dacb-4812-8d73-e4ba693f2c05,2021-11-24T00:17:55,98
-    8370f761-66b1-488e-9327-92a7b8d795b0,2021-11-08T02:55:11,4
-    ff3d9f36-6560-4f26-8627-e18dea66e26b,2021-11-15T07:33:42,89
+    1ad0b69b-0843-4c0d-90a3-d7b77574a3af,2050-11-21T21:24:44,2
+    b504d688-6f02-4d41-8b05-f55a681b940a,2050-11-14T15:29:59,76
+    11502944-dacb-4812-8d73-e4ba693f2c05,2050-11-24T00:17:55,98
+    8370f761-66b1-488e-9327-92a7b8d795b0,2050-11-08T02:55:11,4
+    ff3d9f36-6560-4f26-8627-e18dea66e26b,2050-11-15T07:33:42,89
 
 Spec Formats
 ------------
@@ -952,40 +952,48 @@ REST Server
 Datacraft comes with a lightweight Flask server to use to retrieve generated data. Use the ``--server`` with the optional
 ``--server-endpoint /someendpoint`` flags to launch this server.  The default end point will be found at
 http://127.0.0.1:5000/data. If using a template, each call to the endpoint will return the results of applying a
-single record to the template data. If you specify one of the ``--format`` flags, the formatted record will be returned.
-If neither a formatter or a template are applied, the record for each itertion will be returned.
+single record to the template data. If you specify one of the ``--format`` flags, the formatted record will be returned
+as a string. If neither a formatter or a template are applied, the record for each iteration will be returned as JSON.
+Note that using the ``--records-per-file`` with a number greater than one and a --format of json or json-pretty, will
+produce escaped JSON, which is probably not what you want.
 
-Server side of the transaction, serving up data formatted using the json-pretty formatter. The records contain a
-uuid and a timestamp field.
+Example
+^^^^^^^
+
+For this example we use the inline yaml spec: ``{id:uuid: {}, ts:date.iso: {}}`` as the data we want returned from our
+endpoint. The command below will spin up a flask server that will format the record using the json-pretty formatter.
+The records contain a uuid and a timestamp field.
+
+Sever side of the transaction:
 
 .. code-block:: shell
 
-    $ datacraft --inline "{id:uuid: {}, ts:date: {}}" -i 2 --log-level debug --format json-pretty --server
+    $ datacraft --inline "{id:uuid: {}, ts:date.iso: {}}" -i 2 --log-level debug --format json-pretty --server
      * Serving Flask app 'datacraft.server' (lazy loading)
      * Environment: production
        WARNING: This is a development server. Do not use it in a production deployment.
        Use a production WSGI server instead.
      * Debug mode: off
      * Running on http://127.0.0.1:5000/ (Press CTRL+C to quit)
-    127.0.0.1 - - [23/Nov/2021 20:48:41] "GET /data HTTP/1.1" 200 -
-    127.0.0.1 - - [23/Nov/2021 20:48:44] "GET /data HTTP/1.1" 200 -
+    127.0.0.1 - - [23/Nov/2050 20:48:41] "GET /data HTTP/1.1" 200 -
+    127.0.0.1 - - [23/Nov/2050 20:48:44] "GET /data HTTP/1.1" 200 -
     No more iterations available
-    127.0.0.1 - - [23/Nov/2021 20:48:46] "GET /data HTTP/1.1" 204 -
+    127.0.0.1 - - [23/Nov/2050 20:48:46] "GET /data HTTP/1.1" 204 -
 
-Client side of the transaction
+Client side of the transaction:
 
 .. code-block:: bash
 
     $ curl -s -w "\n%{http_code}\n%" http://127.0.0.1:5000/data
     {
-        "id": "505b62d6-0d21-4965-92a7-f719463fdb0b",
-        "ts": "03-12-2050"
+        "id": "b614698e-1429-4ff7-ac6a-223b26e18b31",
+        "ts": "2050-04-25T08:11:41"
     }
     200
     $ curl -s -w "\n%{http_code}\n%" http://127.0.0.1:5000/data
     {
-        "id": "51e5d07b-4d46-48d7-9523-e1e0ecf723f3",
-        "ts": "09-12-2050"
+       "id": "116a0531-0062-42bc-9224-27774851022b",
+       "ts": "2050-04-27T16:53:04"
     }
     200
     $ curl -s -w "\n%{http_code}\n%" http://127.0.0.1:5000/data

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = datacraft
-version = 0.2.1
+version = 0.2.2
 description = Data Generation Through Specification
 long_description = file: README.md
 long_description_content_type = text/markdown; charset=UTF-8
@@ -30,6 +30,9 @@ install_requires =
     jsonschema~=3.2.0
     asteval~=0.9.25
     importlib-resources~=5.2.2
+
+[options.packages.find]
+exclude = tests, docs
 
 [options.entry_points]
 console_scripts =

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,38 +1,43 @@
 import json
-
+import pytest
 import datacraft
 
 
-def test_server(mocker):
+@pytest.fixture()
+def one():
+    return datacraft.suppliers.count_supplier(data=1)
+
+
+def test_server(mocker, one):
     mocker.patch('datacraft.server.flask.Flask.run', return_value=None)
 
     spec = {"test:uuid": {}}
 
     gen = datacraft.parse_spec(spec).generator(1)
 
-    datacraft.server.run(gen, endpoint='/test', data_is_json=True)
+    datacraft.server.run(gen, endpoint='/test', data_is_json=True, count_supplier=one)
 
 
-def test_server_callback_stop_iteration(mocker):
+def test_server_callback_stop_iteration(mocker, one):
     mocker.patch('flask.jsonify', return_value=None)
     spec = {"test:uuid": {}}
 
     gen = datacraft.parse_spec(spec).generator(1)
 
-    server = datacraft.server._Server(gen, endpoint='/test', data_is_json=True)
+    server = datacraft.server._Server(gen, endpoint='/test', data_is_json=True, count_supplier=one)
 
     # two calls should trigger the StopIteration
     server.callback()
     server.callback()
 
 
-def test_server_callback(mocker):
+def test_server_callback(mocker, one):
     spec = {"test:values": 42}
 
     processor = datacraft.outputs.processor(format_name='json-pretty')
     gen = datacraft.parse_spec(spec).generator(1, processor=processor)
 
-    server = datacraft.server._Server(gen, endpoint='/test', data_is_json=False)
+    server = datacraft.server._Server(gen, endpoint='/test', data_is_json=False, count_supplier=one)
 
     record = server.callback()
     assert record == json.dumps({'test': 42}, indent=4)


### PR DESCRIPTION
Now will return specified number of records per iteration, instead of
single record by default.

Updated cli docs to include records per iteration info

Some code clean up per pylint and pycharm inspections

Bumped to 0.2.2 for this small change/fix