### PR TITLE
Command Line Usage for Registered Types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+v0.4.0
+------
+* Added initial built in type help system with command line --type-list and --type-help and --type-filter command
+  line arguments
+
 v0.3.2
 --------
 * Switched to lru_cache for pre python 3.9 compatibility

--- a/datacraft/__init__.py
+++ b/datacraft/__init__.py
@@ -16,7 +16,7 @@ from .registries import Registry as registry
 from .exceptions import SpecException, ResourceError
 from .supplier.exceptions import SupplierException
 # commonly used by client code
-from .loader import field_loader, Loader
+from .loader import preprocess_and_format, field_loader, Loader
 from . import suppliers, distributions, outputs, utils
 # to trigger registered functions
 from . import cli

--- a/datacraft/_registered_types/calculate.py
+++ b/datacraft/_registered_types/calculate.py
@@ -2,11 +2,20 @@ import json
 import logging
 
 import datacraft
+import datacraft.spec_formatters
 from . import schemas
-from .common import _build_suppliers_map
+from .common import build_suppliers_map
 
 _log = logging.getLogger(__name__)
 _CALCULATE_KEY = 'calculate'
+_EXAMPLE_SPEC = {
+    "height_in": [60, 70, 80, 90],
+    "height_cm": {
+        "type": "calculate",
+        "fields": ["height_in"],
+        "formula": "{{ height_in }} * 2.54"
+    }
+}
 
 
 @datacraft.registry.schemas(_CALCULATE_KEY)
@@ -23,6 +32,12 @@ def _configure_calculate_supplier(field_spec: dict, loader: datacraft.Loader):
     if formula is None:
         raise datacraft.SpecException('Must define formula for calculate type. %s' % json.dumps(field_spec))
 
-    suppliers_map = _build_suppliers_map(field_spec, loader)
+    suppliers_map = build_suppliers_map(field_spec, loader)
 
     return datacraft.suppliers.calculate(suppliers_map=suppliers_map, formula=formula)
+
+
+@datacraft.registry.usage(_CALCULATE_KEY)
+def _example_usage():
+    formatted_spec = datacraft.preprocess_and_format(_EXAMPLE_SPEC)
+    return f'Example Spec:\n{formatted_spec}'

--- a/datacraft/_registered_types/common.py
+++ b/datacraft/_registered_types/common.py
@@ -3,7 +3,7 @@ import json
 import datacraft
 
 
-def _build_suppliers_map(field_spec, loader):
+def build_suppliers_map(field_spec, loader):
     if 'refs' not in field_spec and 'fields' not in field_spec:
         raise datacraft.SpecException('Must define one of fields or refs. %s' % json.dumps(field_spec))
     if 'refs' in field_spec and 'fields' in field_spec:

--- a/datacraft/_registered_types/select_list_subset.py
+++ b/datacraft/_registered_types/select_list_subset.py
@@ -6,14 +6,18 @@ from . import schemas
 
 _log = logging.getLogger(__name__)
 _SELECT_LIST_SUBSET_KEY = 'select_list_subset'
+# alias
+_SAMPLE_KEY = 'sample'
 
 
+@datacraft.registry.schemas(_SAMPLE_KEY)
 @datacraft.registry.schemas(_SELECT_LIST_SUBSET_KEY)
 def _select_list_subset_schema():
     """ schema for select_list_subset type """
     return schemas.load(_SELECT_LIST_SUBSET_KEY)
 
 
+@datacraft.registry.types(_SAMPLE_KEY)
 @datacraft.registry.types(_SELECT_LIST_SUBSET_KEY)
 def _configure_select_list_subset_supplier(field_spec, loader):
     """ configures supplier for select_list_subset type """

--- a/datacraft/_registered_types/templated.py
+++ b/datacraft/_registered_types/templated.py
@@ -3,7 +3,7 @@ import logging
 
 import datacraft
 from . import schemas
-from .common import _build_suppliers_map
+from .common import build_suppliers_map
 
 _log = logging.getLogger(__name__)
 _TEMPLATED_KEY = 'templated'
@@ -18,6 +18,6 @@ def _templated_schema():
 def _configure_templated_type(field_spec, loader):
     if 'data' not in field_spec:
         raise datacraft.SpecException(f'data is required field for templated specs: {json.dumps(field_spec)}')
-    suppliers_map = _build_suppliers_map(field_spec, loader)
+    suppliers_map = build_suppliers_map(field_spec, loader)
 
     return datacraft.suppliers.templated(suppliers_map, field_spec.get('data', None))

--- a/datacraft/cli.py
+++ b/datacraft/cli.py
@@ -8,14 +8,13 @@ import json
 import logging
 import yaml
 
-from . import outputs, utils
-from . import template_engines, builder, spec_formatters, loader, registries
+from . import outputs, utils, usage
+from . import template_engines, builder, spec_formatters, loader, registries, entrypoints
 # this activates the decorators, so they will be discoverable
 from .exceptions import SpecException
 
 # need to import this to trigger registration process
 from . import preprocessor, defaults, distributions
-from . import _registered_types
 
 _log = logging.getLogger(__name__)
 
@@ -48,7 +47,7 @@ def parseargs(argv):
                         help='Path to template to populate, or template inline as a string')
     parser.add_argument('-r', '--records-per-file', dest='records_per_file', default=None, type=int,
                         help='Number of records to place in each file, default is all, requires -o to be specified')
-    parser.add_argument('-k', '--printkey', action='store_true', default=False,
+    parser.add_argument('-k', '--printkey', action='store_true',
                         help='When printing to stdout field name should be printed along with value')
     parser.add_argument('-c', '--code', nargs='+',
                         help='Path to custom defined functions in one or more modules to load')
@@ -62,14 +61,22 @@ def parseargs(argv):
     parser.add_argument('--strict', action='store_true',
                         default=registries.get_default('strict_mode'),
                         help='Enforce schema validation for all registered field specs')
-    parser.add_argument('--apply-raw', action='store_true', dest='apply_raw', default=False,
+    parser.add_argument('--apply-raw', action='store_true', dest='apply_raw',
                         help='Data from -s argument should be applied to the template with out treating as a Data Spec')
-    parser.add_argument('--debug-spec', dest='debug_spec', action='store_true', default=False,
-                        help='Debug spec after internal reformatting')
-    parser.add_argument('--debug-spec-yaml', dest='debug_spec_yaml', action='store_true', default=False,
-                        help='Debug spec after internal reformatting, write out as yaml')
-    parser.add_argument('--debug-defaults', dest='debug_defaults', action='store_true', default=False,
-                        help='List default values from registry after any external code loading')
+    debug_group = parser.add_argument_group('info')
+    debug_group.add_argument('--debug-spec', dest='debug_spec', action='store_true',
+                             help='Debug spec after internal reformatting')
+    debug_group.add_argument('--debug-spec-yaml', dest='debug_spec_yaml', action='store_true',
+                             help='Debug spec after internal reformatting, write out as yaml')
+    debug_group.add_argument('--debug-defaults', dest='debug_defaults', action='store_true',
+                             help='List default values from registry after any external code loading')
+    debug_group.add_argument('--type-list', dest='type_list', action='store_true',
+                             help='Write out the list of registered types')
+    debug_group.add_argument('--type-help', dest='type_help', action='store_true',
+                             help='Write out the help for registered types, specify one or more types to filter by '
+                                  'with --type-filter <name>')
+    debug_group.add_argument('--type-filter', dest='type_filter', metavar='TYPE_NAME', nargs='+',
+                             help='List of types to include in help, requires --type-help to be specified')
     parser.add_argument('-x', '--exclude-internal', dest='exclude_internal', action='store_true',
                         default=registries.get_default('exclude_internal'),
                         help='Do not include non data fields in output records')
@@ -140,6 +147,22 @@ def process_args(args):
     ###################
     # Load Data Spec
     ###################
+
+    # this would bypass spec loading
+    if args.type_list:
+        writer = outputs.get_writer(args.outdir, outfile='type_list.json', overwrite=True)
+        # writer = _get_writer(args)
+        entrypoints.load_eps()
+        all_types = registries.registered_types()
+        for registered_type in all_types:
+            writer.write(registered_type)
+        return None
+    if args.type_help:
+        writer = _get_writer(args)
+        entrypoints.load_eps()
+        usage_str = usage.build_cli_help(args.type_filter)
+        writer.write(usage_str)
+        return None
 
     _log.debug('Attempting to load Data Spec from %s', args.spec if args.spec else args.inline)
     spec = _load_spec(args)

--- a/datacraft/cli.py
+++ b/datacraft/cli.py
@@ -158,7 +158,7 @@ def process_args(args):
             writer.write(registered_type)
         return None
     if args.type_help:
-        writer = _get_writer(args)
+        writer = outputs.get_writer(args.outdir, outfile='type-help.txt', overwrite=True)
         entrypoints.load_eps()
         usage_str = usage.build_cli_help(args.type_filter)
         writer.write(usage_str)

--- a/datacraft/loader.py
+++ b/datacraft/loader.py
@@ -8,7 +8,7 @@ import logging
 from typing import Any, Dict, Union
 from abc import ABC, abstractmethod
 
-from . import utils, suppliers, entrypoints
+from . import utils, suppliers, preprocessor, spec_formatters
 from .exceptions import SpecException
 from .supplier.model import DataSpec, ValueSupplierInterface
 from .schemas import validate_schema_for_spec
@@ -205,6 +205,26 @@ def _validate_schema_for_spec(spec_type: str, field_spec: dict):
     validate_schema_for_spec(spec_type, field_spec, type_schema)
 
 
+def preprocess_and_format(raw_spec: dict) -> str:
+    """Runs all preprocessors and formats spec as string
+
+    Args:
+        raw_spec: to process
+
+    Returns:
+        formatted spec as a string
+
+    Examples:
+        >>> import datacraft
+        >>> @datacraft.registry.usage('custom')
+        ... def _custom_type_usage():
+        ...     spec = datacraft.preprocess_and_format(_EXAMPLE)
+        ...     return f'Example Spec:\\n{spec}'
+    """
+    preprocessed = preprocess_spec(raw_spec)
+    return spec_formatters.format_json(preprocessed)
+
+
 def preprocess_spec(data_spec: Union[Dict[str, Dict], DataSpec]):
     """
     Uses the registered preprocessors to cumulatively update the spec
@@ -219,8 +239,9 @@ def preprocess_spec(data_spec: Union[Dict[str, Dict], DataSpec]):
     updated = dict(raw_spec)
     preprocessors = Registry.preprocessors.get_all()
     for name in preprocessors:
-        preprocessor = Registry.preprocessors.get(name)
-        processed = preprocessor(updated, False)
+        preprocessor_func = Registry.preprocessors.get(name)
+        _log.debug('Running Preprocessor: %s', name)
+        processed = preprocessor_func(updated, False)
         if processed is None:
             _log.error('Invalid preprocessor %s, returned None instead of updated spec, skipping', name)
             continue

--- a/datacraft/registries.py
+++ b/datacraft/registries.py
@@ -30,6 +30,13 @@ class Registry:
             ... def _special_sauce_schema() -> dict:
             ...    # return JSON schema validating specs with type: special_sauce
 
+        usage:
+            Usage for field spec types, used to provide command line help and examples
+
+            >>> @datacraft.registry.usage('special_sauce')
+            ... def _special_sauce_usage() -> str:
+            ...    # return string describing how to use special_sauce
+
         preprocessors:
             Functions to modify specs before data generations process. If there is a customization you want to do for
             every data spec, or an extenstion you added that requires modifications to the spec before they are run,
@@ -84,6 +91,7 @@ class Registry:
     """
     types = catalogue.create('datacraft', 'type')
     schemas = catalogue.create('datacraft', 'schemas')
+    usage = catalogue.create('datacraft', 'usage')
     preprocessors = catalogue.create('datacraft', 'preprocessor')
     logging = catalogue.create('datacraft', 'logging')
     formats = catalogue.create('datacraft', 'format')
@@ -160,6 +168,11 @@ def registered_formats():
 def registered_types():
     """ list of registered types """
     return list(Registry.types.get_all().keys())
+
+
+def registered_usage():
+    """ list of registered usage """
+    return list(Registry.usage.get_all().keys())
 
 
 def registered_casters():

--- a/datacraft/spec_formatters.py
+++ b/datacraft/spec_formatters.py
@@ -83,6 +83,8 @@ def _clean_semi_formatted_yaml(toclean: str):
 
 def _order_spec(raw_spec):
     """ orders the spec by ordering the underlying fields """
+    if isinstance(raw_spec, list):
+        return sorted(raw_spec)
     outer = {}
     for field, spec in raw_spec.items():
         if field == 'refs':
@@ -115,7 +117,7 @@ def _order_field_spec(field_spec):
         ordered['ref'] = field_spec['ref']
     if 'fields' in field_spec:
         fields = field_spec['fields']
-        # these should be full specs themselves
+        # these should be full specs themselves, or possibly lists for case of calculate
         ordered['fields'] = _order_spec(fields)
     if 'config' in field_spec:
         ordered['config'] = field_spec['config']

--- a/datacraft/usage.py
+++ b/datacraft/usage.py
@@ -17,8 +17,9 @@ def build_cli_help(included_types: list = None):
     Returns:
         Formatted usage string from types
     """
+    registered_types = registries.registered_types()
     if included_types is None:
-        included_types = registries.registered_types()
+        included_types = registered_types
     usage_keys = registries.registered_usage()
 
     width = max(len(key) for key in included_types)
@@ -30,6 +31,8 @@ def build_cli_help(included_types: list = None):
             description = func()
 
             entries.append(f'{type_key.ljust(width)} | {description}')
+        elif type_key not in registered_types:
+            entries.append(f'{type_key.ljust(width)} | unknown type')
         else:
             entries.append(f'{type_key.ljust(width)} | no usage defined')
         entries.append(_TYPE_BREAK)

--- a/datacraft/usage.py
+++ b/datacraft/usage.py
@@ -1,0 +1,36 @@
+""" Module to gather usage info from registered types """
+import logging
+
+from . import registries
+
+_TYPE_BREAK = '-------------------------------------'
+
+_log = logging.getLogger(__name__)
+
+
+def build_cli_help(included_types: list = None):
+    """Builds the command line interface help from the registered usage
+
+    Args:
+        included_types: list of type to include, default is to include all
+
+    Returns:
+        Formatted usage string from types
+    """
+    if included_types is None:
+        included_types = registries.registered_types()
+    usage_keys = registries.registered_usage()
+
+    width = max(len(key) for key in included_types)
+
+    entries = [_TYPE_BREAK]
+    for type_key in included_types:
+        if type_key in usage_keys:
+            func = registries.Registry.usage.get(type_key)
+            description = func()
+
+            entries.append(f'{type_key.ljust(width)} | {description}')
+        else:
+            entries.append(f'{type_key.ljust(width)} | no usage defined')
+        entries.append(_TYPE_BREAK)
+    return '\n'.join(entries)

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1024,7 +1024,6 @@ datacraft dependencies. Please install it first with pip or conda. Example using
 REST Server
 -----------
 
-<<<<<<< HEAD
 Datacraft comes with a lightweight Flask server to use to retrieve generated data. Use the ``--server`` with the optional
 ``--server-endpoint /someendpoint`` flags to launch this server.  The default end point will be found at
 http://127.0.0.1:5000/data. If using a template, each call to the endpoint will return the results of applying a
@@ -1039,6 +1038,14 @@ Example
 For this example we use the inline yaml spec: ``{id:uuid: {}, ts:date.iso: {}}`` as the data we want returned from our
 endpoint. The command below will spin up a flask server that will format the record using the json-pretty formatter.
 The records contain a uuid and a timestamp field.
+
+=======
+Datacraft comes with a lightweight Flask server to use to retrieve data generated from a Data Spec. Use the
+``--server`` flag to launch this server. Use the optional ``--server-endpoint /someendpoint`` to customize the endpoint.
+The default end point will be found at http://127.0.0.1:5000/data. If using a template, each call to the endpoint will
+return the results of applying a single record to the template. If you specify one of the ``--format`` flags, the
+formatted records will be returned. If neither a formatter or a template are applied, the record for each iteration
+will be returned.
 
 The code block below is the server side of the transaction. Here the tool is serving up data formatted using the
 json-pretty formatter. The records contain a uuid and a timestamp field.
@@ -1056,7 +1063,6 @@ json-pretty formatter. The records contain a uuid and a timestamp field.
     127.0.0.1 - - [23/Nov/2050 20:48:44] "GET /data HTTP/1.1" 200 -
     No more iterations available
     127.0.0.1 - - [23/Nov/2050 20:48:46] "GET /data HTTP/1.1" 204 -
-
 
 Here is the client side of the transaction, where we perform a GET request on the /data endpoint.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1039,17 +1039,6 @@ For this example we use the inline yaml spec: ``{id:uuid: {}, ts:date.iso: {}}``
 endpoint. The command below will spin up a flask server that will format the record using the json-pretty formatter.
 The records contain a uuid and a timestamp field.
 
-=======
-Datacraft comes with a lightweight Flask server to use to retrieve data generated from a Data Spec. Use the
-``--server`` flag to launch this server. Use the optional ``--server-endpoint /someendpoint`` to customize the endpoint.
-The default end point will be found at http://127.0.0.1:5000/data. If using a template, each call to the endpoint will
-return the results of applying a single record to the template. If you specify one of the ``--format`` flags, the
-formatted records will be returned. If neither a formatter or a template are applied, the record for each iteration
-will be returned.
-
-The code block below is the server side of the transaction. Here the tool is serving up data formatted using the
-json-pretty formatter. The records contain a uuid and a timestamp field.
-
 .. code-block:: shell
 
     $ datacraft --inline "{id:uuid: {}, ts:date.iso: {}}" -i 2 --log-level debug --format json-pretty --server

--- a/tests/test_calculate.py
+++ b/tests/test_calculate.py
@@ -3,8 +3,6 @@ import pytest
 import datacraft
 import datacraft.supplier.calculate
 
-# to trigger registration
-
 simple_calc_data = [
     (
         {'a': 2, 'b': 2},

--- a/tests/test_char_class.py
+++ b/tests/test_char_class.py
@@ -2,7 +2,6 @@ import string
 
 import pytest
 
-# to trigger registration
 from datacraft import builder, field_loader, SpecException
 from datacraft._registered_types.char_class import _CLASS_MAPPING
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -5,8 +5,6 @@ import pytest
 import datacraft
 import datacraft.supplier.csv
 
-# to trigger registration
-
 test_dir = os.sep.join([os.path.dirname(os.path.realpath(__file__)), 'data'])
 
 

--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -7,9 +7,6 @@ from datacraft import builder
 from datacraft.loader import field_loader
 
 
-# to trigger registration
-
-
 def test_basic_spec():
     spec = _date_spec()
     values = _get_unique_values(spec, 'foo')

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -6,9 +6,6 @@ import datacraft
 from datacraft import builder, field_loader
 
 
-# to trigger registration
-
-
 def test_geo_lat_default_precision():
     spec = _geo_lat_spec()
     _test_geo_spec_falls_in_range(spec, 'lat', -90.0, 90.0, -4)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -5,8 +5,6 @@ import pytest
 import datacraft
 from datacraft import builder
 
-# to trigger registration
-
 spec = datacraft.builder.spec_builder() \
     .add_field('foo', builder.combine(['ONE', 'TWO'], join_with='')) \
     .add_ref('ONE', builder.values(['do', 'ca', 'pi'])) \

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,6 +72,30 @@ def test_parse_debug_defaults(tmpdir):
     assert os.path.exists(os.path.join(tmpdir, 'dataspec_defaults.json'))
 
 
+def test_type_list(tmpdir):
+    args = ['--type-list', '-o', str(tmpdir)]
+    dgmain.main(args)
+    assert os.path.exists(os.path.join(tmpdir, 'type_list.json'))
+
+
+def test_type_help_no_filter(tmpdir):
+    args = ['--type-help', '-o', str(tmpdir)]
+    dgmain.main(args)
+    assert os.path.exists(os.path.join(tmpdir, 'type-help.txt'))
+
+
+def test_type_help_with_filter(tmpdir):
+    args = ['--type-help', '--type-filter', 'calculate', 'sample', '-o', str(tmpdir)]
+    dgmain.main(args)
+    assert os.path.exists(os.path.join(tmpdir, 'type-help.txt'))
+
+
+def test_parse_debug_defaults(tmpdir):
+    args = ['--debug-defaults', '-o', str(tmpdir)]
+    dgmain.main(args)
+    assert os.path.exists(os.path.join(tmpdir, 'dataspec_defaults.json'))
+
+
 def test_parse_apply_raw(tmpdir):
     args = ['-o', str(tmpdir),
             '--apply-raw',

--- a/tests/test_nested.py
+++ b/tests/test_nested.py
@@ -4,9 +4,6 @@ import datacraft
 from datacraft import builder, field_loader
 
 
-# to trigger registration
-
-
 def test_single_nested():
     # Geo
     # - Place

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -4,9 +4,6 @@ from datacraft import builder, SpecException
 from datacraft.loader import field_loader
 
 
-# to trigger registration
-
-
 def test_ip_v4_spec():
     spec = _ipv4_spec(cidr="192.168.0.0/16")
 

--- a/tests/test_range_supplier.py
+++ b/tests/test_range_supplier.py
@@ -1,9 +1,6 @@
 from datacraft import builder, field_loader
 
 
-# to trigger registration
-
-
 def test_rand_range():
     spec = builder.spec_builder() \
         .add_field("field", builder.rand_range([100.9, 109.9], cast="int")) \

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -3,9 +3,6 @@ import pytest
 import datacraft
 
 
-# to trigger registration
-
-
 def test_ref_with_ref_name():
     spec_builder = datacraft.spec_builder()
     spec_builder.add_ref('values', datacraft.builder.values([1, 2, 3]))

--- a/tests/test_select_list.py
+++ b/tests/test_select_list.py
@@ -4,9 +4,6 @@ from datacraft import builder, suppliers, SpecException
 from datacraft.loader import field_loader
 
 
-# to trigger registration
-
-
 def test_invalid_when_no_config():
     _test_invalid_select_list_spec({"field:select_list_subset": {}})
 

--- a/tests/test_unicode_range.py
+++ b/tests/test_unicode_range.py
@@ -1,11 +1,6 @@
 import pytest
-from datacraft import builder, field_loader, SpecException
-import pytest
 
 from datacraft import builder, field_loader, SpecException
-
-
-# to trigger registration
 
 
 def test_unicode_no_data_element():

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -22,15 +22,21 @@ def _test_supplier_no_usage(_, __):
     return None
 
 
+def test_usage_misspelled_type():
+    usage_string = datacraft.usage.build_cli_help([DEMO_FOR_TEST+'zzz'])
+    assert DEMO_FOR_TEST+'zzz' in usage_string
+    assert 'unknown type' in usage_string
+
+
 def test_usage_no_filter():
     usage_string = datacraft.usage.build_cli_help()
     assert DEMO_FOR_TEST in usage_string
     assert USAGE_MESSAGE in usage_string
-    assert f'{DEMO_FOR_TEST_NO_USAGE_DEFINED} | no usage defined' in usage_string, usage_string
+    assert f'{DEMO_FOR_TEST_NO_USAGE_DEFINED} | no usage defined' in usage_string
 
 
 def test_usage_constrained():
     usage_string = datacraft.usage.build_cli_help([DEMO_FOR_TEST, DEMO_FOR_TEST_NO_USAGE_DEFINED])
     assert DEMO_FOR_TEST in usage_string
     assert USAGE_MESSAGE in usage_string
-    assert f'{DEMO_FOR_TEST_NO_USAGE_DEFINED} | no usage defined' in usage_string, usage_string
+    assert f'{DEMO_FOR_TEST_NO_USAGE_DEFINED} | no usage defined' in usage_string

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,36 @@
+import datacraft
+import datacraft.usage
+
+USAGE_MESSAGE = 'Usage For Test Only!!!'
+
+DEMO_FOR_TEST = 'demo-for-test'
+DEMO_FOR_TEST_NO_USAGE_DEFINED = 'demo-for-test-no-usage'
+
+
+@datacraft.registry.types(DEMO_FOR_TEST)
+def _test_supplier(_, __):
+    return None
+
+
+@datacraft.registry.usage(DEMO_FOR_TEST)
+def _test_usage():
+    return USAGE_MESSAGE
+
+
+@datacraft.registry.types(DEMO_FOR_TEST_NO_USAGE_DEFINED)
+def _test_supplier_no_usage(_, __):
+    return None
+
+
+def test_usage_no_filter():
+    usage_string = datacraft.usage.build_cli_help()
+    assert DEMO_FOR_TEST in usage_string
+    assert USAGE_MESSAGE in usage_string
+    assert f'{DEMO_FOR_TEST_NO_USAGE_DEFINED} | no usage defined' in usage_string, usage_string
+
+
+def test_usage_constrained():
+    usage_string = datacraft.usage.build_cli_help([DEMO_FOR_TEST, DEMO_FOR_TEST_NO_USAGE_DEFINED])
+    assert DEMO_FOR_TEST in usage_string
+    assert USAGE_MESSAGE in usage_string
+    assert f'{DEMO_FOR_TEST_NO_USAGE_DEFINED} | no usage defined' in usage_string, usage_string

--- a/tests/test_uuid.py
+++ b/tests/test_uuid.py
@@ -4,8 +4,6 @@ import pytest
 
 from datacraft import builder, field_loader
 
-# to trigger registration
-
 UUID_REGEX = re.compile('[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}', re.I)
 
 

--- a/tests/test_weighted_csv.py
+++ b/tests/test_weighted_csv.py
@@ -4,8 +4,6 @@ import pytest
 
 import datacraft
 
-# to trigger registration
-
 test_dir = os.sep.join([os.path.dirname(os.path.realpath(__file__)), 'data'])
 
 

--- a/tests/test_yaml_specs.py
+++ b/tests/test_yaml_specs.py
@@ -2,8 +2,6 @@ import yaml
 
 from datacraft.loader import field_loader
 
-# to trigger registration
-
 yaml_spec = '''
 ---
 foo:


### PR DESCRIPTION
Added --type-list --type-help and --type-filter command line arguments and supporting code.