### PR TITLE
API Doc Updates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+v0.7.0
+------
+* Added `replace` and `regex_replace` types
+* Added `data.iso.ms` and `date.iso.miliis` for iso dates that include milliseconds
+* Added `date.epoch` and `date.epoch.ms` for create dates that are seconds or milliseconds since epoch (Jan 1 1970)
+* Added `datacraft.registered_types()`, `datacraft.registered_formats()`, and `datacraft.registered_casters()` to root.
+* Added `datacraft.type_usage('type-name')` for getting API examples for a given registered type, if that type has API
+usage information provided
+
 v0.6.0
 ------
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 Datacraft
 =========
+
+
 [![Build Status](https://circleci.com/gh/bbux-dev/datacraft/tree/develop.svg?style=shield)](https://circleci.com/gh/bbux-dev/datacraft/tree/main)
 [![codecov](https://codecov.io/gh/bbux-dev/datacraft/branch/develop/graph/badge.svg?token=QFA9QZTQ05)](https://codecov.io/gh/bbux-dev/datacraft)
+
+A tool for generating synthetic data.
 
 Overview
 --------
@@ -24,7 +28,8 @@ modify, update, and manage. It also lends itself to sharing and reuse. Instead o
 synthetic test data, you can build Data Specs that encapsulate the information needed to generate the data. If 
 well-designed, these can be easier to inspect and reason through compared with scanning thousands of lines of a csv 
 file. `datacraft` makes it easy to generate millions or billions of records to use for development and testing of 
-new or existing systems.
+new or existing systems. Datacraft also has a python API so that you can generate your synthetic data as part of your
+test suite or application without have to use online tools or external services.
 
 Docs
 ----
@@ -43,6 +48,8 @@ $ datacraft -h # for full command line usage
 
 Basic Usage
 -----------
+
+### Command Line
 
 ```shell
 $ datacraft type-list # list all available field spec types ...
@@ -76,6 +83,66 @@ combine | Example Spec:
 }
 datacraft -s spec.json -i 3 --format json -x -l off
 [{"name": "zebra jones"}, {"name": "hedgehog smith"}, {"name": "llama williams"}]
+```
+
+### Python API
+
+Basic Usage:
+
+```python
+import datacraft
+
+spec = {
+    "id": {"type": "uuid"},
+    "timestamp": {"type": "date.iso.millis"},
+    "handle": {"type": "cc-word", "config": { "min": 4, "max": 8, "prefix": "@" } }
+}
+
+print(*datacraft.entries(spec, 3), sep='\\n')
+```
+
+```python
+{'id': '40bf8be1-23d2-4e93-9b8b-b37103c4b18c', 'timestamp': '2050-12-03T20:40:03.709', 'handle': '@WPNn'}
+{'id': '3bb5789e-10d1-4ae3-ae61-e0682dad8ecf', 'timestamp': '2050-11-20T02:57:48.131', 'handle': '@kl1KUdtT'}
+{'id': '474a439a-8582-46a2-84d6-58bfbfa10bca', 'timestamp': '2050-11-29T18:08:44.971', 'handle': '@XDvquPI'}
+```
+
+Type Help
+
+```python
+import datacraft
+
+# List all registered types:
+datacraft.registered_types()
+['calculate', 'char_class', 'cc-ascii', 'cc-lower', '...', 'uuid', 'values', 'replace', 'regex_replace']
+
+# Print API usage for a specific type or types
+print(datacraft.type_usage('char_class', 'replace', '...'))
+# Example Output
+"""
+-------------------------------------
+replace | API Example:
+
+import datacraft
+
+spec = {
+ "field": {
+   "type": "values",
+   "data": ["foo", "bar", "baz"]
+ },
+ "replacement": {
+   "type": "replace",
+   "data": {"ba": "fi"},
+   "ref": "field"
+ }
+}
+
+print(*datacraft.entries(spec, 3), sep='\n')
+
+{'field': 'foo', 'replacement': 'foo'}
+{'field': 'bar', 'replacement': 'fir'}
+{'field': 'baz', 'replacement': 'fiz'}
+"""
 ```
 
 For more detailed documentation please see: 

--- a/datacraft/__init__.py
+++ b/datacraft/__init__.py
@@ -1,4 +1,47 @@
-""" init for datacraft """
+""" A tool for generating synthetic data.
+
+Basic Usage:
+
+>>> import datacraft
+>>> spec = {
+...     "id": {"type": "uuid"},
+...     "timestamp": {"type": "date.iso.millis"},
+...     "handle": {"type": "cc-word", "config": { "min": 4, "max": 8, "prefix": "@" } }
+... }
+>>> print(*datacraft.entries(spec, 3), sep='\\n')
+{'id': '40bf8be1-23d2-4e93-9b8b-b37103c4b18c', 'timestamp': '2050-12-03T20:40:03.709', 'handle': '@WPNn'}
+{'id': '3bb5789e-10d1-4ae3-ae61-e0682dad8ecf', 'timestamp': '2050-11-20T02:57:48.131', 'handle': '@kl1KUdtT'}
+{'id': '474a439a-8582-46a2-84d6-58bfbfa10bca', 'timestamp': '2050-11-29T18:08:44.971', 'handle': '@XDvquPI'}
+
+List all registered types:
+>>> datacraft.registered_types()
+['calculate', 'char_class', 'cc-ascii', 'cc-lower', '...', 'uuid', 'values', 'replace', 'regex_replace']
+
+Print API usage for a specific type or types
+>>> print(datacraft.type_usage('char_class', 'replace', '...'))
+-------------------------------------
+replace | API Example:
+
+import datacraft
+
+spec = {
+  "field": {
+    "type": "values",
+    "data": ["foo", "bar", "baz"]
+  },
+  "replacement": {
+    "type": "replace",
+    "data": {"ba": "fi"},
+    "ref": "field"
+  }
+}
+
+print(*datacraft.entries(spec, 3), sep='\n')
+
+{'field': 'foo', 'replacement': 'foo'}
+{'field': 'bar', 'replacement': 'fir'}
+{'field': 'baz', 'replacement': 'fiz'}
+"""
 
 # model classes that may be implemented externally
 from .supplier.model import (
@@ -8,13 +51,18 @@ from .supplier.model import (
 from . import builder
 # expose this at root too
 from .builder import parse_spec, entries
-# registry decorators
-from .registries import Registry as registry
 # exceptions and errors thrown
 from .exceptions import SpecException, ResourceError
 from .supplier.exceptions import SupplierException
 # commonly used by client code
 from .loader import preprocess_and_format, field_loader, Loader
 from . import suppliers, distributions, outputs, utils
+from .usage import build_api_help as type_usage
+from .usage import build_cli_help as cli_usage
+# registry decorators
+from .registries import Registry as registry
+from .registries import registered_types, registered_formats, registered_casters
 # to trigger registered functions
 from . import cli
+from . import entrypoints
+entrypoints.load_eps()

--- a/datacraft/_registered_types/date.py
+++ b/datacraft/_registered_types/date.py
@@ -127,10 +127,13 @@ def _example_date_usage():
             }
         }
     }
-    one = common.standard_example_usage(example_one, 3)
-    two = common.standard_example_usage(example_two, 3)
-    tre = common.standard_example_usage(example_tre, 3)
-    return '\n'.join([one, two, tre])
+    examples = [example_one, example_two, example_tre]
+    clis = [common.standard_cli_example_usage(example, 3) for example in examples]
+    apis = [common.standard_api_example_usage(example, 3) for example in examples]
+    return {
+        'cli': '\n'.join(clis),
+        'api': '\n'.join(apis)
+    }
 
 
 def register_example_date_usage(key):

--- a/datacraft/_registered_types/distribution.py
+++ b/datacraft/_registered_types/distribution.py
@@ -51,7 +51,10 @@ def _example_distribution_usage():
             }
         }
     }
-    one = common.standard_example_usage(example_one, 3)
-    two = common.standard_example_usage(example_two, 3)
-    tre = common.standard_example_usage(example_tre, 3)
-    return '\n'.join([one, two, tre])
+    examples = [example_one, example_two, example_tre]
+    clis = [common.standard_cli_example_usage(example, 3) for example in examples]
+    apis = [common.standard_api_example_usage(example, 3) for example in examples]
+    return {
+        'cli': '\n'.join(clis),
+        'api': '\n'.join(apis)
+    }

--- a/datacraft/_registered_types/replace.py
+++ b/datacraft/_registered_types/replace.py
@@ -78,7 +78,7 @@ def _example_regex_replace_usage():
             }
         }
     }
-    return common.standard_example_usage(example, 4)
+    return common.standard_example_usage(example, 4, pretty=True)
 
 
 class _ReplaceSupplier(ValueSupplierInterface):

--- a/datacraft/builder.py
+++ b/datacraft/builder.py
@@ -94,14 +94,7 @@ def generator(raw_spec: Dict[str, Dict], iterations: int, **kwargs) -> Generator
     return _DataSpecImpl(copy.deepcopy(raw_spec)).generator(iterations, **kwargs)
 
 
-class _DataSpecMeta(type):
-    """ to hide implementation when doing type(spec) """
-
-    def __repr__(cls):
-        return 'DataSpec'
-
-
-class _DataSpecImpl(DataSpec, metaclass=_DataSpecMeta):
+class _DataSpecImpl(DataSpec):
     """ Implementation for DataSpec """
 
     def generator(self, iterations: int, **kwargs):

--- a/datacraft/builder.py
+++ b/datacraft/builder.py
@@ -11,6 +11,7 @@ Examples:
     >>> type(spec)
     DataSpec
 """
+import copy
 import logging
 from typing import Dict, List
 from typing import Generator
@@ -54,6 +55,18 @@ def entries(raw_spec: Dict[str, Dict], iterations: int, **kwargs) -> List[dict]:
 
     Returns:
         the list of N entries
+
+    Examples:
+        >>> import datacraft
+        >>> spec = {
+        ...     "id": {"type": "uuid"},
+        ...     "timestamp": {"type": "date.iso.millis"},
+        ...     "handle": {"type": "cc-word", "config": { "min": 4, "max": 8, "prefix": "@" } }
+        ... }
+        >>> print(*datacraft.entries(spec, 3), sep='\\n')
+        {'id': '40bf8be1-23d2-4e93-9b8b-b37103c4b18c', 'timestamp': '2050-12-03T20:40:03.709', 'handle': '@WPNn'}
+        {'id': '3bb5789e-10d1-4ae3-ae61-e0682dad8ecf', 'timestamp': '2050-11-20T02:57:48.131', 'handle': '@kl1KUdtT'}
+        {'id': '474a439a-8582-46a2-84d6-58bfbfa10bca', 'timestamp': '2050-11-29T18:08:44.971', 'handle': '@XDvquPI'}
     """
     return list(generator(raw_spec, iterations, **kwargs))
 
@@ -78,7 +91,7 @@ def generator(raw_spec: Dict[str, Dict], iterations: int, **kwargs) -> Generator
     Returns:
         the generator for the provided spec
     """
-    return _DataSpecImpl(raw_spec).generator(iterations, **kwargs)
+    return _DataSpecImpl(copy.deepcopy(raw_spec)).generator(iterations, **kwargs)
 
 
 class _DataSpecMeta(type):

--- a/datacraft/cli.py
+++ b/datacraft/cli.py
@@ -168,7 +168,7 @@ def process_args(args):
         all_types = registries.registered_types()
         return _write_info(info=all_types, dest_name='type_list.txt', outdir=args.outdir)
     if 'type_help' in args:
-        usage_str = usage.build_cli_help(args.type_help)
+        usage_str = usage.build_cli_help(*args.type_help)
         return _write_info(info=usage_str, dest_name='type_help.txt', outdir=args.outdir)
     if args.cast_list:
         caster_names = casters.all_names()

--- a/datacraft/distributions.py
+++ b/datacraft/distributions.py
@@ -50,7 +50,7 @@ class BoundedDistribution(Distribution):
     def __init__(self,
                  distribution: Distribution,
                  min_val: float = 0.0,
-                 max_val: float = None):
+                 max_val: Union[float, None] = None):
         """
         Args:
             distribution: to bound

--- a/datacraft/outputs.py
+++ b/datacraft/outputs.py
@@ -314,7 +314,8 @@ def _for_format(key: str) -> RecordProcessor:
         raise SpecException(str(err)) from err
 
 
-def processor(template: Union[str, Path] = None, format_name: str = None) -> Union[None, RecordProcessor]:
+def processor(template: Union[str, Path, None] = None,
+              format_name: Union[str, None] = None) -> Union[None, RecordProcessor]:
     """
     Configures the record level processor for either the template or for the format_name
 
@@ -354,8 +355,8 @@ def processor(template: Union[str, Path] = None, format_name: str = None) -> Uni
     return _processor
 
 
-def get_writer(outdir: str = None,
-               outfile: str = None,
+def get_writer(outdir: Union[str, None] = None,
+               outfile: Union[str, None] = None,
                overwrite: bool = False,
                **kwargs) -> WriterInterface:
     """

--- a/datacraft/spec_formatters.py
+++ b/datacraft/spec_formatters.py
@@ -1,4 +1,5 @@
-"""
+""" data spec formatting
+
 Module with functions that handle formatting specs in an orderly and consistent structure i.e:
 
 .. code-block:: json

--- a/datacraft/supplier/date.py
+++ b/datacraft/supplier/date.py
@@ -12,7 +12,7 @@ _log = logging.getLogger(__name__)
 
 def date_supplier(date_format: str,
                   timestamp_distribution: Distribution,
-                  hour_supplier: ValueSupplierInterface = None) -> ValueSupplierInterface:
+                  hour_supplier: Union[ValueSupplierInterface, None] = None) -> ValueSupplierInterface:
     """
     Creates a value supplier that provides dates with the given format
 
@@ -50,7 +50,7 @@ class _DateSupplier(ValueSupplierInterface):
     def __init__(self,
                  timestamp_distribution: Distribution,
                  date_format_string: str,
-                 hour_supplier: ValueSupplierInterface = None):
+                 hour_supplier: Union[ValueSupplierInterface, None] = None):
         """
         Args:
             timestamp_distribution: distribution for timestamps

--- a/datacraft/supplier/model.py
+++ b/datacraft/supplier/model.py
@@ -3,7 +3,7 @@ Module to hold models for core data structures and classes
 """
 from abc import ABC, abstractmethod
 from collections.abc import Iterator
-from typing import Union, Tuple, List, Any, Generator
+from typing import Union, Tuple, List, Any, Generator, Dict
 
 
 class DataSpec(dict):
@@ -50,6 +50,7 @@ class DataSpec(dict):
     def pop(self, k, d=None):
         return self.raw_spec.pop(k, d)
 
+    @abstractmethod
     def generator(self, iterations: int, **kwargs) -> Generator:
         """
         Creates a generator that will produce records or render the template for each record

--- a/datacraft/supplier/ranges.py
+++ b/datacraft/supplier/ranges.py
@@ -1,6 +1,7 @@
 """ Implementations for range types """
 import math
 import decimal
+from typing import Union
 
 from .model import ValueSupplierInterface, ResettableIterator
 
@@ -36,7 +37,7 @@ class WrappedRangeSupplier(ValueSupplierInterface):
 def float_range(start: float,
                 stop: float,
                 step: float = 1,
-                precision: int = None) -> ResettableIterator:
+                precision: Union[int, None] = None) -> ResettableIterator:
     """
     Fancy foot work to support floating point ranges due to rounding errors with the way floating point numbers are
     stored

--- a/datacraft/supplier/strings.py
+++ b/datacraft/supplier/strings.py
@@ -1,4 +1,6 @@
 """Module for string manipulation suppliers"""
+from typing import Union
+
 import datacraft
 
 
@@ -7,7 +9,7 @@ class _CutSupplier(datacraft.ValueSupplierInterface):
     def __init__(self,
                  wrapped: datacraft.ValueSupplierInterface,
                  start: int = 0,
-                 end: int = None):
+                 end: Union[int, None] = None):
         self.wrapped = wrapped
         self.start = start
         self.end = end
@@ -19,5 +21,5 @@ class _CutSupplier(datacraft.ValueSupplierInterface):
 
 def cut_supplier(supplier: datacraft.ValueSupplierInterface,
                  start: int = 0,
-                 end: int = None):
+                 end: Union[int, None] = None):
     return _CutSupplier(supplier, start, end)

--- a/datacraft/suppliers.py
+++ b/datacraft/suppliers.py
@@ -277,7 +277,7 @@ def list_values(data: list, **kwargs) -> ValueSupplierInterface:
     return list_value_supplier(data, count_supplier(**kwargs), sample, as_list)
 
 
-def weighted_values(data: dict, config: dict = None) -> ValueSupplierInterface:
+def weighted_values(data: dict, config: Union[dict, None] = None) -> ValueSupplierInterface:
     """
     Creates a weighted value supplier from the data, which is a mapping of value to the weight is should represent.
 
@@ -310,7 +310,7 @@ def weighted_values(data: dict, config: dict = None) -> ValueSupplierInterface:
 
 def random_range(start: Union[str, int, float],
                  end: Union[str, int, float],
-                 precision: Union[str, int, float] = None,
+                 precision: Union[str, int, float, None] = None,
                  count: Union[int, List[int], Dict[str, float], Distribution] = 1) -> ValueSupplierInterface:
     """
     Creates a random range supplier for the start and end parameters with the given precision
@@ -906,7 +906,7 @@ def ip_precise(cidr: str, sample: bool = False) -> ValueSupplierInterface:
     return network.ip_precise(cidr, sample)
 
 
-def mac_address(delimiter: str = None) -> ValueSupplierInterface:
+def mac_address(delimiter: Union[str, None] = None) -> ValueSupplierInterface:
     """Creates a value supplier that produces mac addresses
 
     Args:
@@ -929,7 +929,7 @@ def mac_address(delimiter: str = None) -> ValueSupplierInterface:
     return network.mac_address(delimiter)
 
 
-def combine(to_combine, join_with: str = None, as_list: bool = None):
+def combine(to_combine, join_with: Union[str, None] = None, as_list: Union[bool, None] = None):
     """Creates a value supplier that will combine the outputs of the provided suppliers in order. The default is to
     join the values with an empty string. Provide the join_with config param to specify a different string to
     join the values with. Set as_list to true, if the values should be returned as a list and not joined
@@ -960,7 +960,7 @@ def combine(to_combine, join_with: str = None, as_list: bool = None):
     return combine_supplier(to_combine, join_with, as_list)
 
 
-def uuid(variant: int = None) -> ValueSupplierInterface:
+def uuid(variant: Union[int, None] = None) -> ValueSupplierInterface:
     """
     Creates a UUid Value Supplier
 
@@ -1107,7 +1107,7 @@ def templated(supplier_map: Dict[str, ValueSupplierInterface],
 
 def cut(supplier: datacraft.ValueSupplierInterface,
         start: int = 0,
-        end: int = None):
+        end: Union[int, None] = None):
     """Trim output of given supplier from start to end, if length permits
 
     Args:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -5,6 +5,14 @@
 Datacraft API
 =============
 
+The Datacraft API is can be used to generate data in a similar way to the command line tooling. Data Specs are defined
+as dictionaries and follow the JSON based format and schemas. Most of the time you can copy a JSON spec from a file
+and assign it to a variable and it will generate the same data as the command line ``datacraft`` tool.
+
+Example:
+
+Useful functions.
+
 .. contents::
    :depth: 2
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,18 +4,18 @@ import catalogue
 import pytest
 
 import datacraft
-from datacraft import __main__ as dgmain
+from datacraft import __main__ as entrypoint
 
 test_dir = f'{os.path.dirname(os.path.realpath(__file__))}/data'
 
 
 def test_parse_empty_args():
     with pytest.raises(datacraft.SpecException):
-        dgmain.main([])
+        entrypoint.main([])
 
 
 def test_parse_custom_code():
-    dgmain.main(['-c', os.path.join(test_dir, 'custom.py'), '--inline', '{}'])
+    entrypoint.main(['-c', os.path.join(test_dir, 'custom.py'), '--inline', '{}'])
 
     # verify string_reverser is now in registry
     handler = datacraft.registries.lookup_type('string_reverser')
@@ -34,7 +34,7 @@ def test_parse_set_defaults():
 
 def test_parse_set_default_invalid_ignored():
     args = ['--set-defaults', 'incorrect_format', 'is_valid=should_exist', '--inline', '{}']
-    dgmain.main(args)
+    entrypoint.main(args)
     with pytest.raises(catalogue.RegistryError):
         datacraft.registries.get_default('incorrect_format')
 
@@ -46,7 +46,7 @@ def test_parse_sample_mode():
 
 def _test_default_is_changed(key, args, expected):
     orig_value = datacraft.registries.get_default(key)
-    dgmain.main(args)
+    entrypoint.main(args)
     new_value = datacraft.registries.get_default(key)
     # reset default in registry
     datacraft.registries.set_default(key, orig_value)
@@ -56,25 +56,25 @@ def _test_default_is_changed(key, args, expected):
 
 def test_parse_debug_spec(tmpdir):
     args = ['--debug-spec', '-o', str(tmpdir), '--inline', '{foo: [1,2,3]}']
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'generated-0'))
 
 
 def test_parse_debug_spec_yaml(tmpdir):
     args = ['--debug-spec-yaml', '-o', str(tmpdir), '--inline', '{foo: [1,2,3]}']
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'generated-0'))
 
 
 def test_parse_debug_defaults(tmpdir):
     args = ['--debug-defaults', '-o', str(tmpdir)]
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'dataspec_defaults.json'))
 
 
 def test_parse_debug_defaults(tmpdir):
     args = ['--debug-defaults', '-o', str(tmpdir)]
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'dataspec_defaults.json'))
 
 
@@ -83,7 +83,7 @@ def test_parse_apply_raw(tmpdir):
             '--apply-raw',
             '-t', os.path.join(test_dir, 'template.jinja'),
             '--inline', '{"A": 1, "B":2, "C": 3}']
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'generated-0'))
 
 
@@ -91,7 +91,7 @@ def test_parse_template_output(tmpdir):
     args = ['-o', str(tmpdir),
             '-t', os.path.join(test_dir, 'template.jinja'),
             '--inline', '{"A": 1, "B":2, "C": 3}']
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'generated-0'))
 
 
@@ -99,7 +99,7 @@ def test_parse_template_output_inline(tmpdir):
     args = ['-o', str(tmpdir),
             '-t', 'A:{{ A }}, B:{{ B }}, C:{{ C }}',
             '--inline', '{"A": 1, "B":2, "C": 3}']
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'generated-0'))
 
 
@@ -107,7 +107,7 @@ def test_parse_format_output(tmpdir):
     args = ['-o', str(tmpdir),
             '--format', 'json',
             '--inline', '{"A": 1, "B":2, "C": 3}']
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'generated-0'))
 
 
@@ -115,26 +115,26 @@ def test_parse_spec_and_inline_invalid():
     args = ['--spec', os.path.join(test_dir, 'spec.json'),
             '--inline', '{"A": 1, "B":2, "C": 3}']
     with pytest.raises(datacraft.SpecException):
-        dgmain.main(args)
+        entrypoint.main(args)
 
 
 def test_parse_spec_invalid_path():
     args = ['--spec', os.path.join(test_dir, 'spec_not_there.json')]
     # just for test coverage
-    dgmain.main(args)
+    entrypoint.main(args)
 
 
 def test_parse_spec_not_json_or_yaml():
     args = ['--spec', os.path.join(test_dir, 'blank_file')]
     with pytest.raises(datacraft.SpecException):
-        dgmain.main(args)
+        entrypoint.main(args)
 
 
 def test_parse_spec_yaml_format(tmpdir):
     args = ['--spec', os.path.join(test_dir, 'spec.yaml'),
             '-o', str(tmpdir),
             '-i', '5']
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'generated-0'))
 
 
@@ -143,7 +143,7 @@ def test_parse_inline_yaml(tmpdir):
             '--format', 'json',
             '--inline', '{A: 1, B: [2, 4, 6], C: 3}',
             '-i', '5']
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'generated-0'))
 
 
@@ -151,7 +151,7 @@ def test_parse_inline_yaml_blank_string():
     args = ['--format', 'json',
             '--inline', ' ']
     with pytest.raises(datacraft.SpecException):
-        dgmain.main(args)
+        entrypoint.main(args)
 
 
 def test_wrap_main(tmpdir):
@@ -162,7 +162,7 @@ def test_wrap_main(tmpdir):
     import sys
     sys.argv = args
     # for coverage
-    dgmain.wrap_main()
+    entrypoint.wrap_main()
 
 
 def test_server(tmpdir, mocker):
@@ -170,7 +170,7 @@ def test_server(tmpdir, mocker):
     args = ['--format', 'json',
             '--inline', '{A: 1, B: [2, 4, 6], C: 3}',
             '-i', '5', '--server']
-    dgmain.main(args)
+    entrypoint.main(args)
 
 
 def test_var_file_not_there(tmpdir):
@@ -179,7 +179,7 @@ def test_var_file_not_there(tmpdir):
             '-i', '5',
             '-o', str(tmpdir),
             '--var-file', '/cant/find/vars.json']
-    dgmain.main(args)
+    entrypoint.main(args)
     assert not os.path.exists(os.path.join(tmpdir, 'generated-0'))
 
 
@@ -189,7 +189,7 @@ def test_var_file(tmpdir):
             '-i', '5',
             '-o', str(tmpdir),
             '--var-file', os.path.join(test_dir, 'vars.json')]
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'generated-0'))
 
 
@@ -199,7 +199,7 @@ def test_var_args(tmpdir):
             '-i', '5',
             '-o', str(tmpdir),
             '--vars', 'first=a', 'second=b', 'third=c']
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'generated-0'))
 
 
@@ -208,7 +208,7 @@ def test_parse_template_spec_with_vars(tmpdir):
             '--vars', 'pet_count=2',
             '-i', '5',
             '-o', str(tmpdir)]
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'generated-0'))
 
 
@@ -217,7 +217,7 @@ def test_parse_not_json_or_yaml(tmpdir):
             '-i', '5',
             '-o', str(tmpdir)]
     with pytest.raises(datacraft.SpecException):
-        dgmain.main(args)
+        entrypoint.main(args)
 
 
 def test_var_args_not_all_defined(tmpdir):
@@ -227,7 +227,7 @@ def test_var_args_not_all_defined(tmpdir):
             '-o', str(tmpdir),
             '--vars', 'first=a', 'third=c']  # missing second
     with pytest.raises(datacraft.SpecException):
-        dgmain.main(args)
+        entrypoint.main(args)
 
 
 def test_var_args_not_all_defined_no_assignment(tmpdir):
@@ -237,7 +237,7 @@ def test_var_args_not_all_defined_no_assignment(tmpdir):
             '-o', str(tmpdir),
             '--vars', 'first=a', 'second', 'third=c']  # missing second
     with pytest.raises(datacraft.SpecException):
-        dgmain.main(args)
+        entrypoint.main(args)
 
 
 format_key_tests = [
@@ -251,11 +251,11 @@ format_key_tests = [
 @pytest.mark.parametrize("info_flag,filename", format_key_tests)
 def test_write_info_file_created(info_flag, filename, tmpdir):
     args = [info_flag, '-o', str(tmpdir)]
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, filename))
 
 
 def test_type_help_with_filter(tmpdir):
     args = ['--type-help', 'calculate', 'sample', '-o', str(tmpdir)]
-    dgmain.main(args)
+    entrypoint.main(args)
     assert os.path.exists(os.path.join(tmpdir, 'type_help.txt'))

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,10 +1,10 @@
+import pytest
 import datacraft
-import datacraft.usage
 
 USAGE_MESSAGE = 'Usage For Test Only!!!'
 
 DEMO_FOR_TEST = 'demo-for-test'
-DEMO_FOR_TEST_NO_USAGE_DEFINED = 'demo-for-test-no-usage'
+DEMO_FOR_TEST_NO_CLI_USAGE_DEFINED = 'demo-for-test-no-usage'
 
 
 @datacraft.registry.types(DEMO_FOR_TEST)
@@ -14,16 +14,21 @@ def _test_supplier(_, __):
 
 @datacraft.registry.usage(DEMO_FOR_TEST)
 def _test_usage():
-    return USAGE_MESSAGE
+    return {'cli': USAGE_MESSAGE, 'api': USAGE_MESSAGE}
 
 
-@datacraft.registry.types(DEMO_FOR_TEST_NO_USAGE_DEFINED)
+@datacraft.registry.types(DEMO_FOR_TEST_NO_CLI_USAGE_DEFINED)
 def _test_supplier_no_usage(_, __):
     return None
 
 
+@datacraft.registry.usage(DEMO_FOR_TEST_NO_CLI_USAGE_DEFINED)
+def _test_usage_api_only():
+    return {"api": "import datacraft\n#..."}
+
+
 def test_usage_misspelled_type():
-    usage_string = datacraft.usage.build_cli_help([DEMO_FOR_TEST + 'zzz'])
+    usage_string = datacraft.usage.build_cli_help(DEMO_FOR_TEST + 'zzz')
     assert DEMO_FOR_TEST + 'zzz' in usage_string
     assert 'unknown type' in usage_string
 
@@ -32,11 +37,22 @@ def test_usage_no_filter():
     usage_string = datacraft.usage.build_cli_help()
     assert DEMO_FOR_TEST in usage_string
     assert USAGE_MESSAGE in usage_string
-    assert f'{DEMO_FOR_TEST_NO_USAGE_DEFINED} | no usage defined' in usage_string
+    assert f'{DEMO_FOR_TEST_NO_CLI_USAGE_DEFINED} | no cli usage defined' in usage_string
+
+
+def test_api_usage_no_filter():
+    usage_string = datacraft.usage.build_api_help()
+    assert DEMO_FOR_TEST_NO_CLI_USAGE_DEFINED in usage_string
 
 
 def test_usage_constrained():
-    usage_string = datacraft.usage.build_cli_help([DEMO_FOR_TEST, DEMO_FOR_TEST_NO_USAGE_DEFINED])
+    usage_string = datacraft.usage.build_cli_help(DEMO_FOR_TEST, DEMO_FOR_TEST_NO_CLI_USAGE_DEFINED)
     assert DEMO_FOR_TEST in usage_string
     assert USAGE_MESSAGE in usage_string
-    assert f'{DEMO_FOR_TEST_NO_USAGE_DEFINED} | no usage defined' in usage_string
+    assert f'{DEMO_FOR_TEST_NO_CLI_USAGE_DEFINED} | no cli usage defined' in usage_string
+
+
+@pytest.mark.parametrize("key", datacraft.registries.registered_types())
+def test_exercise_all_keys(key):
+    assert key in datacraft.usage.build_cli_help(key)
+    assert key in datacraft.usage.build_api_help(key)


### PR DESCRIPTION
Added more API usage examples to docs

Added `datacraft.registered_types()`, `datacraft.registered_formats()`, and `datacraft.registered_casters()` to root.

Added `datacraft.type_usage('type-name')` for getting API examples for a given registered type, if that type has API usage information provided